### PR TITLE
Introducing AsyncBlockMatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,5 +82,32 @@ func TestSame(t *testing.T) {
 ```
 </details>
 
+<summary><strong>AsyncBlockMatcher</strong> - <em>Matcher which provides channel signaling when `Matches` is called</em></summary>
+
+AsyncBlock returns a matcher holding a channel which will be signaled when
+the `Matches` function is called. AsyncBlock will wrap any other matcher
+to do the actual matching.
+
+This is useful if the code you're testing is spawning a go function which will
+invoke your mock at some time in the future. The channel gives you an easy way
+to wait for that invokation (using `<- matcher.Channel()`) and then do assertions.
+
+```go
+func TestAsyncBlockMatcher(t *testing.T) {
+	assert := assert.New(t)
+	m := matchers.AsyncBlock(gomock.Eq("12"))
+
+	didMatch := false
+	go func() {
+		didMatch = m.Matches("12")
+	}()
+
+  // This blocks until `Matches` is actually called
+	<-m.Channel()
+  assert.True(didMatch)
+}
+```
+</details>
+
 [matcher-interface]: https://godoc.org/github.com/golang/mock/gomock#Matcher
 [golang-gomock]: https://github.com/golang/mock

--- a/asyncblock.go
+++ b/asyncblock.go
@@ -1,0 +1,38 @@
+package matchers
+
+import "github.com/golang/mock/gomock"
+
+type asyncBlockMatcher struct {
+	matcher gomock.Matcher
+	ch      chan struct{}
+}
+
+// AsyncBlock returns a matcher holding a channel which will be signaled when
+// the `Matches` function is called. AsyncBlock will wrap any other matcher
+// to do the actual matching.
+//
+// This is useful if the code you're testing is spawning a go function which will
+// invoke your mock at some time in the future. The channel gives you an easy way
+// to wait for that invokation (using `<- matcher.Channel()`) and then do assertions.
+func AsyncBlock(matcher gomock.Matcher) *asyncBlockMatcher {
+	return &asyncBlockMatcher{
+		ch:      make(chan struct{}),
+		matcher: matcher,
+	}
+}
+
+// Channel returns a channel which will have an empty struct written to it every time
+// `Matches` is invoked.
+func (m *asyncBlockMatcher) Channel() <-chan struct{} {
+	return m.ch
+}
+
+func (m *asyncBlockMatcher) Matches(x interface{}) bool {
+	b := m.matcher.Matches(x)
+	m.ch <- struct{}{}
+	return b
+}
+
+func (m *asyncBlockMatcher) String() string {
+	return m.matcher.String()
+}

--- a/asyncblock_test.go
+++ b/asyncblock_test.go
@@ -1,0 +1,42 @@
+package matchers_test
+
+import (
+	"testing"
+
+	matchers "github.com/Storytel/gomock-matchers"
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAsyncBlockMatcherPassthrough(t *testing.T) {
+	type MyType int
+
+	assert := assert.New(t)
+	m := matchers.AsyncBlock(gomock.Eq(MyType(24)))
+
+	go func() { <-m.Channel() }()
+	assert.False(m.Matches(24))
+
+	go func() { <-m.Channel() }()
+	assert.True(m.Matches(MyType(24)))
+}
+
+func TestAsyncBlockMatcher(t *testing.T) {
+
+	assert := assert.New(t)
+	m := matchers.AsyncBlock(gomock.Eq("12"))
+
+	ch := make(chan bool)
+	go func() {
+		ch <- m.Matches("12")
+	}()
+
+	<-m.Channel()
+	assert.True(<-ch)
+}
+
+func TestAsyncBlockMatcherString(t *testing.T) {
+	assert := assert.New(t)
+	m := matchers.AsyncBlock(gomock.Any())
+	assert.Equal("is anything", m.String()) // This is String() from gomock.anyMatcher
+}

--- a/recording_test.go
+++ b/recording_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type MyType int
-
 func TestRecordMatcherPassthrough(t *testing.T) {
+	type MyType int
+
 	assert := assert.New(t)
 	m := matchers.Record(gomock.Eq(MyType(12)))
 


### PR DESCRIPTION
AsyncBlock returns a matcher holding a channel which will be signaled when
the `Matches` function is called. AsyncBlock will wrap any other matcher
to do the actual matching.