### PR TITLE
Add Regexp Matcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,25 @@ func TestSomething(t *testing.T) {
 
 # Matchers
 
+
+<details>
+<summary><strong>RegexpMatcher</strong> - <em>Matcher which accepts a string to be interpreted as a <a href="https://golang.org/pkg/regexp/">Go Regexp</a>.</em></summary>
+
+Regexpmatcher returns a matcher which will match if the supplied string, interpreted
+as a regexp, matches the input string.
+
+This is useful when you don't know exactly what the string might be in a run.
+Maybe it's a timestamp or something else outside of your control.
+
+```go
+func TestRegexpMatcher(t *testing.T) {
+  m := matchers.Regexp("^[^@]+@.+$")
+  m.Matches("donald_duck@duckburg.di") // true
+  m.Matches("daisy") // false
+}
+```
+</details>
+
 <details>
 <summary><strong>RecordMatcher</strong> - <em>Proxy matcher which captures the argument for further inspection.</em></summary>
 Wraps another matcher and records the value of the argument it's called with.
@@ -105,7 +124,7 @@ func TestAsyncBlockMatcher(t *testing.T) {
 
   // This blocks until `Matches` is actually called
 	<-m.Channel()
-  assert.True(didMatch)
+	assert.True(didMatch)
 }
 ```
 </details>

--- a/regex.go
+++ b/regex.go
@@ -1,0 +1,29 @@
+package matchers
+
+import (
+	"fmt"
+	"regexp"
+)
+
+type regexpMatcher struct {
+	pattern *regexp.Regexp
+}
+
+func Regexp(pattern string) *regexpMatcher {
+	return &regexpMatcher{
+		pattern: regexp.MustCompile(pattern),
+	}
+}
+
+func (m *regexpMatcher) String() string {
+	return fmt.Sprintf("matches pattern /%v/", m.pattern)
+}
+
+func (m *regexpMatcher) Matches(x interface{}) bool {
+	s, ok := x.(string)
+	if !ok {
+		return false
+	}
+
+	return m.pattern.MatchString(s)
+}

--- a/regex_test.go
+++ b/regex_test.go
@@ -1,0 +1,59 @@
+package matchers_test
+
+import (
+	"fmt"
+	"testing"
+
+	matchers "github.com/Storytel/gomock-matchers"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegexpMatcher(t *testing.T) {
+
+	testCases := []struct {
+		pattern string
+		value   interface{}
+		matches bool
+	}{
+		{"^something .*", "something good", true},
+		{"^something .*", "that's something good", false},
+		{"^[0-9][1-5]a?$", "42a", true},
+		{".*", 12, false},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("Test #%d", i), func(t *testing.T) {
+			assert := assert.New(t)
+			m := matchers.Regexp(testCase.pattern)
+			assert.Equal(testCase.matches, m.Matches(testCase.value))
+		})
+	}
+}
+
+func TestRegexpMatcherCompileError(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("invalid regexp did not panic")
+		}
+	}()
+	_ = matchers.Regexp("^(abc$")
+}
+
+func TestRegexpMatcherString(t *testing.T) {
+	testCases := []struct {
+		pattern string
+		str     string
+	}{
+		{"^[a-z]$", "matches pattern /^[a-z]$/"},
+		{"asdf", "matches pattern /asdf/"},
+		{"something[[:space:]]", "matches pattern /something[[:space:]]/"},
+	}
+
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("Test #%d", i), func(t *testing.T) {
+			assert := assert.New(t)
+			m := matchers.Regexp(testCase.pattern)
+			assert.Equal(testCase.str, m.String())
+		})
+	}
+}


### PR DESCRIPTION
Adds a matcher which takes a string to interpreted as a regular
expression accoring to the [regexp][1] package.

This can be useful when the string might vary depending on factors that
are outside of the testers control (or simply not worth the effort of
taking control over) such as a timestamp.

[1]: https://golang.org/pkg/regexp/