### PR TITLE
Export all matchers

### DIFF
--- a/asyncblock.go
+++ b/asyncblock.go
@@ -2,7 +2,7 @@ package matchers
 
 import "github.com/golang/mock/gomock"
 
-type asyncBlockMatcher struct {
+type AsyncBlockMatcher struct {
 	matcher gomock.Matcher
 	ch      chan struct{}
 }
@@ -14,8 +14,8 @@ type asyncBlockMatcher struct {
 // This is useful if the code you're testing is spawning a go function which will
 // invoke your mock at some time in the future. The channel gives you an easy way
 // to wait for that invokation (using `<- matcher.Channel()`) and then do assertions.
-func AsyncBlock(matcher gomock.Matcher) *asyncBlockMatcher {
-	return &asyncBlockMatcher{
+func AsyncBlock(matcher gomock.Matcher) *AsyncBlockMatcher {
+	return &AsyncBlockMatcher{
 		ch:      make(chan struct{}),
 		matcher: matcher,
 	}
@@ -23,16 +23,16 @@ func AsyncBlock(matcher gomock.Matcher) *asyncBlockMatcher {
 
 // Channel returns a channel which will have an empty struct written to it every time
 // `Matches` is invoked.
-func (m *asyncBlockMatcher) Channel() <-chan struct{} {
+func (m *AsyncBlockMatcher) Channel() <-chan struct{} {
 	return m.ch
 }
 
-func (m *asyncBlockMatcher) Matches(x interface{}) bool {
+func (m *AsyncBlockMatcher) Matches(x interface{}) bool {
 	b := m.matcher.Matches(x)
 	m.ch <- struct{}{}
 	return b
 }
 
-func (m *asyncBlockMatcher) String() string {
+func (m *AsyncBlockMatcher) String() string {
 	return m.matcher.String()
 }

--- a/recording.go
+++ b/recording.go
@@ -2,7 +2,7 @@ package matchers
 
 import "github.com/golang/mock/gomock"
 
-type recordMatcher struct {
+type RecordMatcher struct {
 	x interface{}
 	m gomock.Matcher
 }
@@ -11,21 +11,21 @@ type recordMatcher struct {
 // provided matcher - following all the matching rules of that
 // matcher. In addition, the argument which is matched is recorded
 // and can later be retrieved for inspection using the Get() func
-func Record(m gomock.Matcher) *recordMatcher {
-	return &recordMatcher{
+func Record(m gomock.Matcher) *RecordMatcher {
+	return &RecordMatcher{
 		m: m,
 	}
 }
 
-func (rm *recordMatcher) Matches(x interface{}) bool {
+func (rm *RecordMatcher) Matches(x interface{}) bool {
 	rm.x = x
 	return rm.m.Matches(x)
 }
 
-func (rm *recordMatcher) String() string {
+func (rm *RecordMatcher) String() string {
 	return rm.m.String()
 }
 
-func (rm *recordMatcher) Get() interface{} {
+func (rm *RecordMatcher) Get() interface{} {
 	return rm.x
 }

--- a/regex.go
+++ b/regex.go
@@ -5,21 +5,21 @@ import (
 	"regexp"
 )
 
-type regexpMatcher struct {
+type RegexpMatcher struct {
 	pattern *regexp.Regexp
 }
 
-func Regexp(pattern string) *regexpMatcher {
-	return &regexpMatcher{
+func Regexp(pattern string) *RegexpMatcher {
+	return &RegexpMatcher{
 		pattern: regexp.MustCompile(pattern),
 	}
 }
 
-func (m *regexpMatcher) String() string {
+func (m *RegexpMatcher) String() string {
 	return fmt.Sprintf("matches pattern /%v/", m.pattern)
 }
 
-func (m *regexpMatcher) Matches(x interface{}) bool {
+func (m *RegexpMatcher) Matches(x interface{}) bool {
 	s, ok := x.(string)
 	if !ok {
 		return false

--- a/same.go
+++ b/same.go
@@ -2,19 +2,19 @@ package matchers
 
 import "fmt"
 
-type sameMatcher struct {
+type SameMatcher struct {
 	x interface{}
 }
 
 // Same will return a new Same matcher which uses `==` comparison
-func Same(x interface{}) *sameMatcher {
-	return &sameMatcher{x}
+func Same(x interface{}) *SameMatcher {
+	return &SameMatcher{x}
 }
 
-func (m *sameMatcher) String() string {
+func (m *SameMatcher) String() string {
 	return fmt.Sprintf("is same as '%v'", m.x)
 }
 
-func (m *sameMatcher) Matches(x interface{}) bool {
+func (m *SameMatcher) Matches(x interface{}) bool {
 	return m.x == x
 }


### PR DESCRIPTION
It's bad practice to not export types that are returned by exported functions. It makes it very hard to work with the package except in the most basic cases.