### PR TITLE
AsyncBlock: Add buffer to async block channel

### DIFF
--- a/asyncblock.go
+++ b/asyncblock.go
@@ -16,7 +16,7 @@ type AsyncBlockMatcher struct {
 // to wait for that invokation (using `<- matcher.Channel()`) and then do assertions.
 func AsyncBlock(matcher gomock.Matcher) *AsyncBlockMatcher {
 	return &AsyncBlockMatcher{
-		ch:      make(chan struct{}),
+		ch:      make(chan struct{}, 1024),
 		matcher: matcher,
 	}
 }


### PR DESCRIPTION
There's no need to keep the matcher blocked until the channel is read. The channel is intended as a signal only, but if it's not read we don't want that goroutine to stick around forever.